### PR TITLE
Synced to sync

### DIFF
--- a/docs/app/routes/components/highlights.tsx
+++ b/docs/app/routes/components/highlights.tsx
@@ -87,7 +87,7 @@ const highlights = [
       "Seamlessly handles both complex monorepos and simple single-package projects with equal ease.",
     features: [
       "Async mode for independent versions",
-      "Synced mode for lockstep releases",
+      "Sync mode for lockstep releases",
       "Automatic dependency management",
     ],
     img: (

--- a/docs/content/docs/configuration/configuration.mdx
+++ b/docs/content/docs/configuration/configuration.mdx
@@ -54,14 +54,14 @@ Customize TurboVersion's behavior through a `version.config.json` file or CLI ar
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `synced` | `boolean` | `false` | Whether all packages share versions |
+| `sync` | `boolean` | `false` | Whether all packages share versions |
 | `updateInternalDependencies` | `"major"` \| `"minor"` \| `"patch"` \| `false` | `"patch"` | How to bump cross-package deps |
 | `skip` | `string[]` | `[]` | Packages to exclude from versioning |
 
 **Monorepo Example:**
 ```json
 {
-  "synced": false,
+  "sync": false,
   "updateInternalDependencies": "minor",
   "skip": ["internal-utils"]
 }
@@ -100,7 +100,7 @@ Customize TurboVersion's behavior through a `version.config.json` file or CLI ar
   "baseBranch": "develop",
   "versionStrategy": "commitMessage",
   "preset": "angular",
-  "synced": false,
+  "sync": false,
   "updateInternalDependencies": "minor",
   "prereleaseIdentifier": "rc",
   "skip": ["docs", "test-utils"],
@@ -127,7 +127,7 @@ turboversion bump \
    {
      "tagPrefix": "${packageName}@",
      "updateInternalDependencies": "minor",
-     "synced": false
+     "sync": false
    }
    ```
 

--- a/docs/content/docs/configuration/recipes.mdx
+++ b/docs/content/docs/configuration/recipes.mdx
@@ -27,7 +27,7 @@ description: Battle-tested configurations for real-world scenarios
 ### 2. Monorepo (Independent Versions)
 ```json
 {
-  "synced": false,
+  "sync": false,
   "tagPrefix": "${packageName}@",
   "updateInternalDependencies": "minor",
   "skip": ["docs", "examples"]
@@ -42,7 +42,7 @@ description: Battle-tested configurations for real-world scenarios
 ### 3. Monorepo (Lockstep Versions)
 ```json
 {
-  "synced": true,
+  "sync": true,
   "tagPrefix": "release-",
   "commitMessage": "chore(release): v${version} [skip-ci]"
 }
@@ -130,7 +130,7 @@ turboversion bump --preid beta
 ### 3. Enterprise Monorepo
 ```json
 {
-  "synced": false,
+  "sync": false,
   "tagPrefix": "pkg-",
   "analyzeCommitsSince": "last-week",
   "updateInternalDependencies": false,

--- a/docs/content/docs/references/cli-reference.mdx
+++ b/docs/content/docs/references/cli-reference.mdx
@@ -19,7 +19,7 @@ turboversion bump [options]
 | `--package <name>` | Target specific package | `bump --package @app/core` |
 | `--dry-run` | Preview changes | `bump --dry-run` |
 | `--async` | Async mode (monorepos) | `bump --async` |
-| `--synced` | Synced mode | `bump --synced` |
+| `--sync` | Sync mode | `bump --sync` |
 
 **Examples**:
 ```bash

--- a/docs/content/docs/references/glossary.mdx
+++ b/docs/content/docs/references/glossary.mdx
@@ -26,7 +26,7 @@ A standardized commit message format:
 
 ## Versioning Modes
 
-### Synced Mode
+### Sync Mode
 All packages share the same version number.
 *Use case*: Full-stack apps where frontend/backend versions stay aligned.
 

--- a/docs/content/docs/release-modes/async.mdx
+++ b/docs/content/docs/release-modes/async.mdx
@@ -11,7 +11,7 @@ Async mode enables **granular version control** by only updating packages with a
 # Run in async mode (default for monorepos)
 turboversion bump --async
 # or via config
-{ "synced": false }
+{ "sync": false }
 ```
 
 ## How Async Mode Works
@@ -68,7 +68,7 @@ api:   (unchanged)    (no commits → no bump)
 **Example Config:**
 ```json
 {
-  "synced": false,
+  "sync": false,
   "updateInternalDependencies": "minor",
   "tagPrefix": "pkg-"
 }
@@ -106,7 +106,7 @@ api:   (unchanged)    (no commits → no bump)
 → Set `updateInternalDependencies` to `"minor"` or `"major"` for stricter updates
 
 **Q: How to force all packages to update?**
-→ Use synced mode instead:
+→ Use sync mode instead:
 ```bash
-@turboversion/version bump --synced
+@turboversion/version bump --sync
 ```

--- a/docs/content/docs/release-modes/sync.mdx
+++ b/docs/content/docs/release-modes/sync.mdx
@@ -9,9 +9,9 @@ Sync mode ensures **all packages share the same version number**, ideal for tigh
 
 ```bash
 # Enable via CLI
-turboversion bump --synced
+turboversion bump --sync
 # Or in config
-{ "synced": true }
+{ "sync": true }
 ```
 
 ## When to Use Sync Mode
@@ -58,7 +58,7 @@ turboversion bump --synced
 ### Basic Setup
 ```json
 {
-  "synced": true,
+  "sync": true,
   "tagPrefix": "v",
   "baseBranch": "main"
 }
@@ -67,7 +67,7 @@ turboversion bump --synced
 ### With Pre-releases
 ```json
 {
-  "synced": true,
+  "sync": true,
   "prereleaseIdentifier": "beta",
   "commitMessage": "chore(release): v${version} [skip-ci]"
 }
@@ -86,7 +86,7 @@ packages/
 **Config:**
 ```json
 {
-  "synced": true,
+  "sync": true,
   "updateInternalDependencies": false,
   "tagPrefix": "lib-"
 }
@@ -110,11 +110,11 @@ git commit -m "feat: add user profile system"
 ### Switching from Async to Sync
 1. Just change config:
    ```json
-   { "synced": true }
+   { "sync": true }
    ```
 2. Update config:
    ```json
-   { "synced": true }
+   { "sync": true }
    ```
 3. Verify with dry run:
    ```bash
@@ -123,11 +123,11 @@ git commit -m "feat: add user profile system"
 
 ## Troubleshooting
 
-**Q: Some packages shouldn't be synced**
+**Q: Some packages shouldn't be sync**
 → Use `skip` for exceptions:
 ```json
 {
-  "synced": true,
+  "sync": true,
   "skip": ["docs", "legacy"]
 }
 ```

--- a/docs/content/docs/support/about.mdx
+++ b/docs/content/docs/support/about.mdx
@@ -47,7 +47,7 @@ npm install -g @turboversion/version
 ### 🧩 Monorepo Optimized
 - Tracks dependencies between packages
 - Only versions changed packages (async mode)
-- Or keeps all packages in sync (synced mode)
+- Or keeps all packages in sync (sync mode)
 - Updates cross-package references automatically
 
 ### ⚙️ Flexible Configuration
@@ -56,7 +56,7 @@ npm install -g @turboversion/version
 {
   "tagPrefix": "v",
   "preset": "angular",
-  "synced": false,
+  "sync": false,
   "updateInternalDependencies": "patch"
 }
 ```

--- a/docs/content/docs/support/faq.mdx
+++ b/docs/content/docs/support/faq.mdx
@@ -28,7 +28,7 @@ turboversion bump --preid beta  # v1.0.0-beta.1
 
 ## Monorepos
 
-### Q: Synced vs Async mode - which should I use?
+### Q: Sync vs Async mode - which should I use?
 | **Sync Mode** | **Async Mode** |
 |--------------|---------------|
 | All packages share one version | Packages version independently |
@@ -109,7 +109,7 @@ git push --follow-tags  # Critical for CI/CD
 2. Convert config:
    ```diff
    - "version": "independent"
-   + "synced": false
+   + "sync": false
    ```
 
 ### Q: Coming from Changesets?

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -4,7 +4,7 @@ This is a command-line tool that allows you to bump the versions of your package
 
 ## Usage
 
-You can use **Turboversion** in two ways: **synced**, **async** mode, and **manually** or **affected** packages by commits since the last release.
+You can use **Turboversion** in two ways: **sync**, **async** mode, and **manually** or **affected** packages by commits since the last release.
 
 ```bash
 
@@ -12,14 +12,14 @@ yarn add -D turboversion
 
 ```
 
-### Synced
+### Sync
 
-In `synced` mode, all packages in the monorepo or common repo will be updated with the same version and tag. This means that when a new version is released, all packages will have the same version number and git tag. This is useful when you want to maintain consistency across all packages.
+In `sync` mode, all packages in the monorepo or common repo will be updated with the same version and tag. This means that when a new version is released, all packages will have the same version number and git tag. This is useful when you want to maintain consistency across all packages.
 
-- Monorepo example - If you have a monorepo with three packages (package A, package B, and package C), and you release version 1.0.0 in synced mode, all three packages will have the same version number (1.0.0) and git tag (v1.0.0). If you make changes to package A and release a new version (e.g., 1.1.0), all three packages will be updated to version 1.1.0 with the git tag v1.1.0.
+- Monorepo example - If you have a monorepo with three packages (package A, package B, and package C), and you release version 1.0.0 in sync mode, all three packages will have the same version number (1.0.0) and git tag (v1.0.0). If you make changes to package A and release a new version (e.g., 1.1.0), all three packages will be updated to version 1.1.0 with the git tag v1.1.0.
 - Common repo - If you have a common repo, it will update the package version.
 
-For monorepos `synced` mode is typically used when all packages in the are closely related and should be updated together. However, if you only want to update the packages that have been affected by changes since the last release, you can run the command with `synced=false` or leave it undefined. In this mode, only the packages that have been affected by changes will be updated to the new version.
+For monorepos `sync` mode is typically used when all packages in the are closely related and should be updated together. However, if you only want to update the packages that have been affected by changes since the last release, you can run the command with `sync=false` or leave it undefined. In this mode, only the packages that have been affected by changes will be updated to the new version.
 
 ### Async (just for monorepos)
 
@@ -97,10 +97,10 @@ This is a JSON schema used to configure the versioning process for a project. Th
 
 The following properties are defined in the schema:
 
-- `tagPrefix`: A string property that represents the prefix used for Git tags in the project. This property is usually set to the name of the project. `${projectName}@` or just `v` for synced workspaces.
+- `tagPrefix`: A string property that represents the prefix used for Git tags in the project. This property is usually set to the name of the project. `${projectName}@` or just `v` for sync workspaces.
 - `preset`: A property that specifies the commit message convention preset used by the commitizen tool in the project. The property is a string with a default value of "angular" and can only take one of the two possible string values - "angular" or "conventional".(Only used if `versionStrategy` is set to "commitMessage").
 - `baseBranch`: A string property that represents the Git branch that should be used as the base for versioning in the project.
-- `synced`: A boolean property that indicates whether or not the local Git repository is synced with the remote repository.
+- `sync`: A boolean property that indicates whether or not the local Git repository is sync with the remote repository.
 - `updateInternalDependencies`: A property that specifies how to update internal dependencies between packages. The property is a string with a default value of "patch" and can only take one of the three possible string values - "major", "minor", or "patch". Alternatively, the property can be set to the boolean value `false` to disable automatic updates.
 - `skip`: A list of package names that should be excluded from the versioning process. When you specify one or more package names in this list, those packages will be skipped in the versioning process. This is useful when you have packages that don't need to be versioned, or that require additional steps before they can be published.
 - `commitMessage`: A string property that represents the commit message pattern used by the commitizen tool in the project. This property is a regular expression. Example: `chore(new version): release version ${version} [skip-ci]` or `chore(${packageName}): release version ${version} [skip-ci]`.

--- a/packages/version/src/bump-command/async-mode.ts
+++ b/packages/version/src/bump-command/async-mode.ts
@@ -47,7 +47,7 @@ export async function asyncFlux(config: Config, type?: ReleaseType) {
         const tagPrefix = formatTagPrefix({
           tagPrefix: config.tagPrefix,
           name,
-          synced: config.synced,
+          sync: config.sync,
         });
         const latestTag = await getLatestTag(tagPrefix);
 

--- a/packages/version/src/bump-command/index.ts
+++ b/packages/version/src/bump-command/index.ts
@@ -32,7 +32,7 @@ export function bumpCommand(): Command {
     )
     .option(
       "-t, --target <project>",
-      "Specific project to version (ignored in synced mode)"
+      "Specific project to version (ignored in sync mode)"
     )
     .addOption(
       new Option("-b, --bump <version>", "Specify version bump type")
@@ -65,16 +65,16 @@ export function bumpCommand(): Command {
           config.branchPattern = ["major", "minor", "patch"];
         }
 
-        if (config.synced && options.target) {
+        if (config.sync && options.target) {
           console.log(
             chalk.yellow.bold("⚠ Warning:") +
               chalk.yellow(
-                " Target option ignored in synced mode. All projects will be versioned together."
+                " Target option ignored in sync mode. All projects will be versioned together."
               )
           );
         }
 
-        if (config.synced) {
+        if (config.sync) {
           await syncedFlux(config, options.bump);
         } else if (options.bump && options.target) {
           await singleFlux(config, options);

--- a/packages/version/src/bump-command/single-mode.ts
+++ b/packages/version/src/bump-command/single-mode.ts
@@ -22,8 +22,7 @@ export async function singleFlux(config: Config, options: any) {
     const packages = pkgs
       .filter(
         (pkg) =>
-          pkgNames.some((name) => name === pkg.packageJson.name) &&
-          !config.synced
+          pkgNames.some((name) => name === pkg.packageJson.name) && !config.sync
       )
       .filter((pkg) => !config.skip?.some((sp) => sp === pkg.packageJson.name));
 
@@ -33,7 +32,7 @@ export async function singleFlux(config: Config, options: any) {
       const tagPrefix = formatTagPrefix({
         tagPrefix: config.tagPrefix,
         name,
-        synced: config.synced,
+        sync: config.sync,
       });
 
       const latestTag = await getLatestTag(tagPrefix);

--- a/packages/version/src/bump-command/sync-mode.ts
+++ b/packages/version/src/bump-command/sync-mode.ts
@@ -18,7 +18,7 @@ export async function syncedFlux(config: Config, type?: ReleaseType) {
     const { packages } = getPackagesSync(cwd());
 
     const tagPrefix = formatTagPrefix({
-      synced: config.synced,
+      sync: config.sync,
     });
     const { preset, baseBranch, branchPattern } = config;
 

--- a/packages/version/src/init-command/index.ts
+++ b/packages/version/src/init-command/index.ts
@@ -78,8 +78,8 @@ export function initCommand(): Command {
           },
           {
             type: "confirm",
-            name: "synced",
-            message: "Use synced mode for all packages?",
+            name: "sync",
+            message: "Use sync mode for all packages?",
             default: false,
           },
         ]);

--- a/packages/version/src/setup/index.ts
+++ b/packages/version/src/setup/index.ts
@@ -13,7 +13,7 @@ export type Config = {
   tagPrefix: string;
   preset: string;
   baseBranch: string;
-  synced: boolean;
+  sync: boolean;
   packages: string[];
   updateInternalDependencies:
     | "major"

--- a/packages/version/src/utils/format-tag.ts
+++ b/packages/version/src/utils/format-tag.ts
@@ -3,14 +3,10 @@ import { createTemplateString } from "./template-string";
 type TagFormat = {
   tagPrefix?: string;
   name?: string;
-  synced: boolean;
+  sync: boolean;
 };
 
-export function formatTagPrefix({
-  tagPrefix,
-  name,
-  synced,
-}: TagFormat): string {
+export function formatTagPrefix({ tagPrefix, name, sync }: TagFormat): string {
   if (tagPrefix != null) {
     return createTemplateString(tagPrefix, {
       target: name,
@@ -18,7 +14,7 @@ export function formatTagPrefix({
     });
   }
 
-  if (synced) {
+  if (sync) {
     return "v";
   }
 

--- a/packages/version/tests/utils/FormatTag.test.ts
+++ b/packages/version/tests/utils/FormatTag.test.ts
@@ -2,29 +2,29 @@ import { describe, expect, test } from "@jest/globals";
 import { formatTag, formatTagPrefix } from "../../src/utils/FormatTag";
 
 describe("formatTagPrefix", () => {
-   test("returns tagPrefix with substituted variables when tagPrefix is defined", () => {
-      const result = formatTagPrefix({
-         tagPrefix: "v${target}-",
-         name: "my-package",
-         synced: false,
-      });
-      expect(result).toBe("vmy-package-");
-   });
+  test("returns tagPrefix with substituted variables when tagPrefix is defined", () => {
+    const result = formatTagPrefix({
+      tagPrefix: "v${target}-",
+      name: "my-package",
+      sync: false,
+    });
+    expect(result).toBe("vmy-package-");
+  });
 
-   test('returns "v" when synced is true and tagPrefix is not defined', () => {
-      const result = formatTagPrefix({ synced: true });
-      expect(result).toBe("v");
-   });
+  test('returns "v" when sync is true and tagPrefix is not defined', () => {
+    const result = formatTagPrefix({ sync: true });
+    expect(result).toBe("v");
+  });
 
-   test("returns name with hyphen when synced is false and tagPrefix is not defined", () => {
-      const result = formatTagPrefix({ name: "my-package", synced: false });
-      expect(result).toBe("my-package-");
-   });
+  test("returns name with hyphen when sync is false and tagPrefix is not defined", () => {
+    const result = formatTagPrefix({ name: "my-package", sync: false });
+    expect(result).toBe("my-package-");
+  });
 });
 
 describe("formatTag", () => {
-   test("returns tag with prefix", () => {
-      const result = formatTag({ tagPrefix: "v", version: "1.0.0" });
-      expect(result).toBe("v1.0.0");
-   });
+  test("returns tag with prefix", () => {
+    const result = formatTag({ tagPrefix: "v", version: "1.0.0" });
+    expect(result).toBe("v1.0.0");
+  });
 });

--- a/packages/version/turbov.schema.json
+++ b/packages/version/turbov.schema.json
@@ -1,103 +1,75 @@
 {
-   "$schema": "http://json-schema.org/draft-07/schema#",
-   "type": "object",
-   "additionalProperties": false,
-   "properties": {
-      "prereleaseIdentifier": {
-         "type": "string",
-         "minLength": 1,
-         "description": "The prerelease identifier to use when bumping the version",
-         "examples": [
-            "beta",
-            "alpha"
-         ]
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "prereleaseIdentifier": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The prerelease identifier to use when bumping the version",
+      "examples": ["beta", "alpha"]
+    },
+    "tagPrefix": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The prefix used for Git tags, usually the project name"
+    },
+    "versionStrategy": {
+      "type": "string",
+      "enum": ["branchPattern", "commitMessage"],
+      "default": "commitMessage",
+      "description": "The versioning strategy to use, either 'branchPattern' or 'commitMessage'. Select 'branchPattern' if you want to calculate the version based on the branch name, and 'commitMessage' if you want to calculate the version based on the commit message.",
+      "examples": [
+        "branchPattern => v1.0.0 branchPattern 'patch*' => v1.0.1, branchPattern 'minor*' => v1.1.0, branchPattern 'major*' => v2.0.0"
+      ]
+    },
+    "preset": {
+      "type": "string",
+      "enum": ["angular", "conventional"],
+      "default": "angular",
+      "description": "The commit message convention preset used by commitizen. That applies only when `versionStrategy` is 'commitMessage'"
+    },
+    "branchPattern": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Pattern to match the branch name"
       },
-      "tagPrefix": {
-         "type": "string",
-         "minLength": 1,
-         "description": "The prefix used for Git tags, usually the project name"
+      "uniqueItems": true,
+      "minItems": 1,
+      "description": "The pattern to match the branch name. Only applies when `versionStrategy` is 'branchPattern'",
+      "examples": [["major, minor, patch"], ["break, feat, fix"]]
+    },
+    "commitMessage": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The commit message, this is just a commit message template, not related with `versionStrategy`.",
+      "examples": [
+        "[skip-ci]",
+        "chore(${projectName}): release version ${version} [skip-ci]"
+      ]
+    },
+    "sync": {
+      "type": "boolean",
+      "description": "Whether or not the local Git repository is sync with the remote repository"
+    },
+    "updateInternalDependencies": {
+      "type": "string",
+      "enum": ["major", "minor", "patch", false],
+      "description": "How to update internal dependencies between packages"
+    },
+    "skip": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Name of the package to skip"
       },
-      "versionStrategy": {
-         "type": "string",
-         "enum": [
-            "branchPattern",
-            "commitMessage"
-         ],
-         "default": "commitMessage",
-         "description": "The versioning strategy to use, either 'branchPattern' or 'commitMessage'. Select 'branchPattern' if you want to calculate the version based on the branch name, and 'commitMessage' if you want to calculate the version based on the commit message.",
-         "examples": [
-            "branchPattern => v1.0.0 branchPattern 'patch*' => v1.0.1, branchPattern 'minor*' => v1.1.0, branchPattern 'major*' => v2.0.0"
-         ]
-      },
-      "preset": {
-         "type": "string",
-         "enum": [
-            "angular",
-            "conventional"
-         ],
-         "default": "angular",
-         "description": "The commit message convention preset used by commitizen. That applies only when `versionStrategy` is 'commitMessage'"
-      },
-      "branchPattern": {
-         "type": "array",
-         "items": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Pattern to match the branch name"
-         },
-         "uniqueItems": true,
-         "minItems": 1,
-         "description": "The pattern to match the branch name. Only applies when `versionStrategy` is 'branchPattern'",
-         "examples": [
-            [
-               "major, minor, patch"
-            ],
-            [
-               "break, feat, fix"
-            ]
-         ]
-      },
-      "commitMessage": {
-         "type": "string",
-         "minLength": 1,
-         "description": "The commit message, this is just a commit message template, not related with `versionStrategy`.",
-         "examples": [
-            "[skip-ci]",
-            "chore(${projectName}): release version ${version} [skip-ci]"
-         ]
-      },
-      "synced": {
-         "type": "boolean",
-         "description": "Whether or not the local Git repository is synced with the remote repository"
-      },
-      "updateInternalDependencies": {
-         "type": "string",
-         "enum": [
-            "major",
-            "minor",
-            "patch",
-            false
-         ],
-         "description": "How to update internal dependencies between packages"
-      },
-      "skip": {
-         "type": "array",
-         "items": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Name of the package to skip"
-         },
-         "uniqueItems": true,
-         "example": [
-            "ui",
-            "docs"
-         ],
-         "description": "A list of package names to skip publishing. When specified, these packages will be excluded from the publish process."
-      }
-   },
-   "required": [
-      "tagPrefix",
-      "baseBranch",
-      "updateInternalDependencies"
-   ]
+      "uniqueItems": true,
+      "example": ["ui", "docs"],
+      "description": "A list of package names to skip publishing. When specified, these packages will be excluded from the publish process."
+    }
+  },
+  "required": ["tagPrefix", "baseBranch", "updateInternalDependencies"]
 }

--- a/version.config.json
+++ b/version.config.json
@@ -6,6 +6,6 @@
   "prereleaseIdentifier": "beta",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "synced": true,
+  "sync": true,
   "commitMessage": "chore(v): release version ${version} [skip-ci]"
 }


### PR DESCRIPTION
## Changes
- Renamed configuration parameter `synced` → `sync` (breaking change)
- Updated all internal references and documentation
- Added deprecation warning for `synced` usage

## Migration Required
Update your `version.config.json`:
```diff
{
-  "synced": true,
+  "sync": true,
}